### PR TITLE
poc: fully private k8s via talos + tailnet

### DIFF
--- a/cilium.tf
+++ b/cilium.tf
@@ -56,13 +56,15 @@ data "helm_template" "cilium" {
       ipam = {
         mode = "kubernetes"
       }
+      extraArgs             = var.cilium_tailscale_enabled ? ["--direct-routing-device=tailscale0"] : []
       routingMode           = var.cilium_routing_mode
       ipv4NativeRoutingCIDR = local.network_native_routing_ipv4_cidr
       policyCIDRMatchMode   = var.cilium_policy_cidr_match_mode
       bpf = {
-        masquerade        = var.cilium_kube_proxy_replacement_enabled
-        datapathMode      = var.cilium_bpf_datapath_mode
-        hostLegacyRouting = local.cilium_ipsec_enabled
+        masquerade          = var.cilium_kube_proxy_replacement_enabled
+        datapathMode        = var.cilium_bpf_datapath_mode
+        hostLegacyRouting   = local.cilium_ipsec_enabled
+        lbExternalClusterIP = var.cilium_tailscale_enabled # ref: https://forum.tailscale.com/t/tailscale-proxy-in-k8s-with-cilium-works-with-pod-not-with-svc/1910/5
       }
       encryption = {
         enabled = var.cilium_encryption_enabled

--- a/image.tf
+++ b/image.tf
@@ -1,5 +1,5 @@
 locals {
-  talos_schematic_id = coalesce(var.talos_schematic_id, talos_image_factory_schematic.this[0].id)
+  talos_schematic_id = coalesce(var.talos_schematic_id)
 
   talos_installer_image_url = data.talos_image_factory_urls.amd64.urls.installer
   talos_amd64_image_url     = data.talos_image_factory_urls.amd64.urls.disk_image

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,6 +39,19 @@ output "talos_machine_configurations_worker" {
   sensitive   = true
 }
 
+output "talos_machine_secrets" {
+  description = "Talos machine secrets. Used for generating talos machine-configs outside this module."
+  value       = talos_machine_secrets.this.machine_secrets
+  sensitive   = true
+}
+
+output "kube_api_internal" {
+  description = "Kube API endpoint. Used for generating talos machine-configs outside this module."
+  value       = local.kube_api_url_internal
+  sensitive   = true
+}
+
+
 output "control_plane_private_ipv4_list" {
   description = "List of private IPv4 addresses assigned to control plane nodes."
   value       = local.control_plane_private_ipv4_list

--- a/server.tf
+++ b/server.tf
@@ -40,7 +40,10 @@ resource "hcloud_server" "control_plane" {
   firewall_ids = [local.firewall_id]
 
   public_net {
-    ipv4_enabled = var.talos_public_ipv4_enabled
+    # NOTE: till https://github.com/siderolabs/talos/issues/7184 lands, we need internet egress on a node itself
+    # as it's not possible to configure to use tailscale subnet router as a NAT gateway for internet egress, on a talos node;
+    # so attach ipv6 and remove all inbound traffic to all control-plane nodes, except from hcloud network
+    ipv4_enabled = var.talos_public_ipv4_enabled || var.cluster_access == "private"
     ipv6_enabled = var.talos_public_ipv6_enabled
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1546,6 +1546,13 @@ variable "cilium_hubble_ui_enabled" {
 }
 
 
+variable "cilium_tailscale_enabled" {
+  type        = bool
+  default     = false
+  description = "Enables changes to cillium config, required by a tailscale network devices and taiscale operator."
+}
+
+
 # Metrics Server
 variable "metrics_server_helm_repository" {
   type        = string


### PR DESCRIPTION
fix: patch cillium for tailscale device, don't sync kubelet via cillium_net on proxmox nodes, for now we'll handle that manually

fix: quick hack to get a public IP attached as a workaround for non-working NAT gateway, firewall rules still restrict all inbound